### PR TITLE
Bump SmallestCSVParser to 1.2.0 (7.5% speedup)

### DIFF
--- a/CsharpCSVBench.csproj
+++ b/CsharpCSVBench.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="NReco.Csv" Version="1.0.3" />
     <PackageReference Include="Sep" Version="0.5.5" />
-    <PackageReference Include="SmallestCSVParser" Version="1.1.1" />
+    <PackageReference Include="SmallestCSVParser" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
   <None Update="data/Table_1_Authors_career_2023_pubs_since_1788_wopp_extracted_202408_justnames.csv">


### PR DESCRIPTION
Before:

> | ScanSmallestCSVParser | 47.232 ms | 0.3233 ms | 0.3024 ms |  0.249       |  55299.1 KB |

After:

> | ScanSmallestCSVParser | 44.026 ms | 0.1987 ms | 0.1859 ms |  0.268       | 55299.09 KB |


Also, CsvHelper is 33% faster but has 9000% more lines of code (9700 vs 100).    Talk about diminishing returns...

> | ScanCsvHelper         | 33.270 ms | 0.0961 ms | 0.0802 ms |  0.354       | 18266.48 KB |

Anyway, cool project!
